### PR TITLE
Allow QuickIOPathInfo object to be created for paths which do not exist

### DIFF
--- a/src/QuickIO.NET/Internal/InternalQuickIO.FindData.cs
+++ b/src/QuickIO.NET/Internal/InternalQuickIO.FindData.cs
@@ -109,13 +109,19 @@ namespace SchwabenCode.QuickIO.Internal
         public static Win32FindData GetFindDataFromPath( string fullpath, QuickIOFileSystemEntryType? estimatedFileSystemEntryType = null )
         {
             Contract.Requires( fullpath != null );
-            Contract.Ensures( Contract.Result<Win32FindData>() != null );
-
+            //Changed to allow paths which do not exist:
+            //Contract.Ensures( Contract.Result<Win32FindData>() != null );
+            if (!QuickIOPath.Exists(fullpath))
+            {
+                return null;
+            }
             Win32FindData win32FindData = SafeGetFindDataFromPath( fullpath );
 
             if( win32FindData == null )
             {
-                throw new PathNotFoundException( fullpath );
+                //Changed to allow paths which do not exist:
+                //throw new PathNotFoundException( fullpath );
+                return null;                
             }
 
             // Check for correct type

--- a/src/QuickIO.NET/QuickIOFileSystemEntryBase.cs
+++ b/src/QuickIO.NET/QuickIOFileSystemEntryBase.cs
@@ -34,11 +34,12 @@ namespace SchwabenCode.QuickIO
             if( findData != null )
             {
                 this.Attributes = findData.dwFileAttributes;
+                //Changed to allow paths which do not exist:
+                _lastWriteTimeUtc = FindData.GetLastWriteTimeUtc();
+                _lastAccessTimeUtc = findData.GetLastAccessTimeUtc();
+                _creationTimeUtc = findData.GetCreationTimeUtc();
             }
 
-            _lastWriteTimeUtc = FindData.GetLastWriteTimeUtc();
-            _lastAccessTimeUtc = findData.GetLastAccessTimeUtc();
-            _creationTimeUtc = findData.GetCreationTimeUtc();
         }
         #endregion
 

--- a/src/QuickIO.NET/QuickIOPathInfo.cs
+++ b/src/QuickIO.NET/QuickIOPathInfo.cs
@@ -37,7 +37,8 @@ namespace SchwabenCode.QuickIO
         internal QuickIOPathInfo( string fullpath, Win32FindData win32FindData )
         {
             Contract.Requires( fullpath != null );
-            Contract.Requires( win32FindData != null );
+            //Changed to allow paths which do not exist:
+            //Contract.Requires( win32FindData != null );
 
             this.FindData = win32FindData;
 

--- a/src/QuickIO.NET/project.json
+++ b/src/QuickIO.NET/project.json
@@ -1,10 +1,10 @@
 ﻿{
-  "version": "2.9.0-*",
-  "description": "QuickIO Main Library",
-  "authors": [ "Benjamin Abt" ],
+  "version": "2.9.1-*",
+  "description": "QuickIO Main Library (Fork)",
+  "authors": [ "Avinash Puchalapalli", "Benjamin Abt" ],
   "tags": [ "QuickIO", "QuickIO.NET", "File Operations", "BenjaminAbt", "SCHWABENCODE" ],
-  "projectUrl": "https://github.com/SchwabenCode/QuickIO",
-  "licenseUrl": "https://github.com/SchwabenCode/QuickIO/LICENSE.md",
+  "projectUrl": "https://github.com/holycrepe/QuickIO",
+  "licenseUrl": "https://github.com/holycrepe/QuickIO/LICENSE.md",
   "frameworks": {
     "dnx46": {
       "dependencies": {


### PR DESCRIPTION
I find it useful to create a `PathInfo` object for paths which do not exist, as it allows use of the `Exists` property, such as to check if a path exists, permit a download to use that filename, etc. 

This is how the native `System.IO.FileInfo` and `System.IO.DirectoryInfo` objects operate. I noticed `QuickIOPathInfo` throws errors if paths do not exist. Was there a particular reason you require paths to exist before creating an `Info` object? If not, I've submitted this PR which makes a few changes so that errors are not thrown when paths do not exist. 

For better compatibility with your existing code, I can also make this optional with a boolean flag used by the constructor, that is set to false by default. Let me know if that would be helpful and I'll make the necessary changes
